### PR TITLE
Change bcdHID version in XInput configuration descriptor to 1.00

### DIFF
--- a/src/descriptors/XInputDescriptors.h
+++ b/src/descriptors/XInputDescriptors.h
@@ -114,7 +114,7 @@ static const uint8_t xinput_configuration_descriptor[] =
 
 	0x10,        // bLength
 	0x21,        // bDescriptorType (HID)
-	0x10, 0x01,  // bcdHID 1.10
+	0x00, 0x01,  // bcdHID 1.00
 	0x01,        // bCountryCode
 	0x24,        // bNumDescriptors
 	0x81,        // bDescriptorType[0] (Unknown 0x81)


### PR DESCRIPTION
This fixes compatibility issues with UsbdSec-patched Xbox 360s.

When bcdHID is declared as version 1.10, multiple titles have issues with controller input:
 - Analog inputs (sticks and triggers) do not work in Xbox 360 Dashboard, Aurora and various games
 - Controller inputs are not recognized at all in Tony Hawk's American Wasteland and Tony Hawk's Project 8

Just changing it to 1.00 is enough to fix those issues.
It doesn't seem to break compatibility with other devices (tested on Windows PC) and should also fix issues described in https://github.com/wiredopposite/OGX-Mini/issues/23